### PR TITLE
Change how formatting errors is done

### DIFF
--- a/.changeset/wild-snails-cry.md
+++ b/.changeset/wild-snails-cry.md
@@ -1,0 +1,5 @@
+---
+"@arundo/typed-env": minor
+---
+
+change how formatting errors is done

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -1,11 +1,11 @@
-import { ZodError } from 'zod';
+import { ZodIssue } from 'zod';
 import { Replace, CamelKeys, ConstantKeys, KebabKeys, PascalKeys } from 'string-ts';
 
 export type NamingConvention = 'camelcase' | 'pascalcase' | 'kebabcase' | 'constantcase' | 'default';
 
 export type Options<TTransform, TPrefixRemoval> = {
   transform?: TTransform;
-  formatErrorFn?: (error: ZodError) => string;
+  constructErrorFn?: (issues: ZodIssue[]) => Error;
   excludePrefix?: TPrefixRemoval;
 };
 


### PR DESCRIPTION
- Instead of providing a format error message, provide a construct error handler.
- Also do not check instanceof ZodError as that fails in certain cases.